### PR TITLE
Fix read-only buffer error in annalist-describe

### DIFF
--- a/annalist.el
+++ b/annalist.el
@@ -558,6 +558,9 @@ one."
 (declare-function org-table-align "org-table")
 (declare-function outline-next-heading "outline")
 (defvar org-startup-folded)
+(defvar org-startup-align-all-tables)
+(defvar org-startup-shrink-all-tables)
+
 ;;;###autoload
 (defun annalist-describe (annalist type &optional view)
   "Describe information recorded by ANNALIST for TYPE.
@@ -586,18 +589,15 @@ those settings for displaying recorded information instead of the defaults."
           (princ "* Global\n"))
         (annalist--print-headings name-store 0 settings local-name-store)))
     (when (or local-name-store name-store)
+      (require 'org)
       (with-current-buffer output-buffer-name
-        (let ((org-startup-folded annalist-org-startup-folded))
-          (org-mode))
         (read-only-mode -1)
+        (let ((org-startup-folded annalist-org-startup-folded)
+              (org-startup-align-all-tables t)
+              (org-startup-shrink-all-tables nil))
+          (org-mode))
         ;; TODO delete empty tables then headings (e.g. if predicate for row
         ;; fails but predicate for headings didn't)
-        (while (progn
-                 (while (progn
-                          (forward-line)
-                          (org-at-heading-p)))
-                 (org-table-align)
-                 (outline-next-heading)))
         (goto-char (point-min))
         (dolist (view-hook view-hooks)
           (funcall view-hook))


### PR DESCRIPTION
Fix read-only-buffer error in annalist-describe when `org-startup-align-all-tables' is set to t.